### PR TITLE
feat: 選択した行動指針を打刻記録シートに保存 (closes #6)

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -189,7 +189,12 @@ function verifyStaff(uuid, birthdateStr) {
  *     placeId: string,
  *     type: string, // 'in' | 'out' など
  *     qrValue: string, // 実際に読み取ったQRの文字列（ログに残したければ）
+ *     guidelineId: string, // 選択した行動指針のID（1〜7）
+ *     guidelineText: string, // 選択した行動指針の文言
  *   }
+ *
+ * 打刻記録シートの列順:
+ *   timestamp / uuid / name / placeId / type / userAgent / guidelineId / guidelineText
  */
 function recordTimestamp(payload) {
   const ss = SpreadsheetApp.getActiveSpreadsheet();
@@ -207,7 +212,9 @@ function recordTimestamp(payload) {
     payload.name || '',
     payload.placeId || '',
     payload.type || '',
-    userAgent
+    userAgent,
+    payload.guidelineId || '',
+    payload.guidelineText || ''
   ]);
 
   // メッセージ生成

--- a/index.html
+++ b/index.html
@@ -840,12 +840,20 @@
       stopCamera();
       scanStatus.textContent = "送信中...";
 
+      const selectedGuidelineEl = document.querySelector('input[name="guideline"]:checked');
+      const guidelineId = selectedGuidelineEl ? selectedGuidelineEl.value : '';
+      const guidelineText = selectedGuidelineEl
+        ? (selectedGuidelineEl.closest('.guideline-option')?.querySelector('span')?.textContent || '').trim()
+        : '';
+
       const payload = {
         uuid: selectedStaffUuid,
         name: selectedStaffName,
         placeId: placeId,
         type: selectedType,
-        qrValue: qrData
+        qrValue: qrData,
+        guidelineId: guidelineId,
+        guidelineText: guidelineText
       };
 
       try {

--- a/standalone.html
+++ b/standalone.html
@@ -833,12 +833,20 @@
             stopCamera();
             scanStatus.textContent = "送信中...";
 
+            const selectedGuidelineEl = document.querySelector('input[name="guideline"]:checked');
+            const guidelineId = selectedGuidelineEl ? selectedGuidelineEl.value : '';
+            const guidelineText = selectedGuidelineEl
+                ? (selectedGuidelineEl.closest('.guideline-option')?.querySelector('span')?.textContent || '').trim()
+                : '';
+
             const payload = {
                 uuid: selectedStaffUuid,
                 name: selectedStaffName,
                 placeId: placeId,
                 type: selectedType,
-                qrValue: qrData
+                qrValue: qrData,
+                guidelineId: guidelineId,
+                guidelineText: guidelineText
             };
 
             try {


### PR DESCRIPTION
## Summary
- 打刻時に STEP3 で選択した行動指針（ID と文言）を payload に含めて送信
- バックエンド `recordTimestamp` で打刻記録シートに `guidelineId` / `guidelineText` の2列を追加して書き込み
- 既存の `timestamp / uuid / name / placeId / type / userAgent` の右側に追加するため、後方互換あり

## 関連 Issue
Closes #6

## 打刻記録シートの列順（変更後）
\`timestamp / uuid / name / placeId / type / userAgent / guidelineId / guidelineText\`

※ ヘッダー行を運用しているシートでは、`G列` / `H列` に「guidelineId」「guidelineText」を追加してください（appendRow なので未追加でも書き込みは可能）。

## Test plan
- [ ] STEP1〜STEP3 を進めて行動指針を選択
- [ ] STEP4 で QR を読み取って打刻
- [ ] 打刻記録シートの G列 / H列 に選択した行動指針のIDと文言が記録されることを確認
- [ ] 行動指針を未選択のまま打刻した場合（理論上は発生しないがフォールバック）、空文字が入ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)