### PR TITLE
feat: 退室時は行動指針選択をスキップする (closes #8)

### DIFF
--- a/index.html
+++ b/index.html
@@ -512,9 +512,24 @@
       <div id="verifyFeedback" class="verify-feedback"></div>
     </section>
 
-    <!-- STEP 3: GUIDELINE -->
+    <!-- STEP 3: TYPE (入退室タイプ選択) -->
+    <section class="card disabled-section" id="sec-type">
+      <div class="card-title">STEP 3: 入退室の選択</div>
+      <div class="type-switcher" id="typeSwitcher">
+        <div class="type-btn" data-type="in" onclick="selectType('in')">
+          <span class="type-icon"><i class="fa-solid fa-door-open"></i></span>
+          <span>入室</span>
+        </div>
+        <div class="type-btn" data-type="out" onclick="selectType('out')">
+          <span class="type-icon"><i class="fa-solid fa-door-closed"></i></span>
+          <span>退室</span>
+        </div>
+      </div>
+    </section>
+
+    <!-- STEP 4: GUIDELINE (入室時のみ) -->
     <section class="card disabled-section" id="sec-guideline">
-      <div class="card-title">STEP 3: 行動指針選択</div>
+      <div class="card-title">STEP 4: 行動指針選択</div>
       <p class="guideline-hint">今日意識する指針を1つ選んでください。</p>
       <div class="guideline-list" id="guidelineList">
         <label class="guideline-option"><input type="radio" name="guideline" value="1"><span>感謝を、当たり前に: いつも感謝を忘れない。支えられていることに気づき、全ての人・モノに感謝する。</span></label>
@@ -527,21 +542,9 @@
       </div>
     </section>
 
-    <!-- STEP 4: SCAN -->
+    <!-- STEP 5: SCAN -->
     <section class="card disabled-section" id="sec-scan">
-      <div class="card-title">STEP 4: 打刻</div>
-
-      <div class="type-switcher" id="typeSwitcher">
-        <div class="type-btn" data-type="in" onclick="selectType('in')">
-          <span class="type-icon"><i class="fa-solid fa-door-open"></i></span>
-          <span>入室</span>
-        </div>
-        <div class="type-btn" data-type="out" onclick="selectType('out')">
-          <span class="type-icon"><i class="fa-solid fa-door-closed"></i></span>
-          <span>退室</span>
-        </div>
-      </div>
-
+      <div class="card-title">STEP 5: QRコード読み取り</div>
       <div class="camera-box">
         <video id="video" autoplay muted playsinline></video>
         <div class="scan-line" id="scanLine"></div>
@@ -616,6 +619,7 @@
     // UI Refs
     const secStaff = document.getElementById('sec-staff');
     const secVerify = document.getElementById('sec-verify');
+    const secType = document.getElementById('sec-type');
     const secGuideline = document.getElementById('sec-guideline');
     const secScan = document.getElementById('sec-scan');
     const staffGrid = document.getElementById('staffGrid');
@@ -646,7 +650,7 @@
             selectedGuideline = input.value;
             secScan.classList.remove('disabled-section');
             scrollToEl(secScan);
-            scanStatus.textContent = "「入室」または「退室」を選択してください";
+            if (!scanning) startCamera();
           }
         });
       });
@@ -731,8 +735,11 @@
       birthInput.value = '';
       verifyFeedback.textContent = '';
       selectedGuideline = null;
+      selectedType = null;
+      typeBtns.forEach(btn => btn.classList.remove('active'));
       guidelineInputs.forEach((input) => { input.checked = false; });
       document.querySelectorAll('.guideline-option').forEach((lbl) => lbl.classList.remove('selected'));
+      secType.classList.add('disabled-section');
       secGuideline.classList.add('disabled-section');
       secScan.classList.add('disabled-section');
       stopCamera();
@@ -768,8 +775,8 @@
           verified = true;
           verifyFeedback.textContent = 'OK: ' + res.name;
           verifyFeedback.className = 'verify-feedback success';
-          secGuideline.classList.remove('disabled-section');
-          scrollToEl(secGuideline);
+          secType.classList.remove('disabled-section');
+          scrollToEl(secType);
         } else {
           verifyFeedback.textContent = '生年月日が一致しません';
           verifyFeedback.className = 'verify-feedback error';
@@ -789,7 +796,22 @@
         if (btn.dataset.type === type) btn.classList.add('active');
         else btn.classList.remove('active');
       });
-      if (!scanning) startCamera();
+
+      // 入室時のみ行動指針セクションを表示。退室時はスキップして直接スキャンへ。
+      if (type === 'in') {
+        secGuideline.classList.remove('disabled-section');
+        secScan.classList.add('disabled-section');
+        stopCamera();
+        scrollToEl(secGuideline);
+      } else {
+        selectedGuideline = null;
+        guidelineInputs.forEach((input) => { input.checked = false; });
+        document.querySelectorAll('.guideline-option').forEach((lbl) => lbl.classList.remove('selected'));
+        secGuideline.classList.add('disabled-section');
+        secScan.classList.remove('disabled-section');
+        scrollToEl(secScan);
+        if (!scanning) startCamera();
+      }
     };
 
     function startCamera() {
@@ -898,6 +920,7 @@
       isVerifying = false;
       selectedType = null;
       secVerify.classList.add('disabled-section');
+      secType.classList.add('disabled-section');
       secScan.classList.add('disabled-section');
       birthInput.value = '';
       verifyFeedback.textContent = '';

--- a/standalone.html
+++ b/standalone.html
@@ -511,9 +511,24 @@
             <div id="verifyFeedback" class="verify-feedback"></div>
         </section>
 
-        <!-- STEP 3: GUIDELINE -->
+        <!-- STEP 3: TYPE (入退室タイプ選択) -->
+        <section class="card disabled-section" id="sec-type">
+            <div class="card-title">STEP 3: 入退室の選択</div>
+            <div class="type-switcher" id="typeSwitcher">
+                <div class="type-btn" data-type="in" onclick="selectType('in')">
+                    <span class="type-icon"><i class="fa-solid fa-door-open"></i></span>
+                    <span>入室</span>
+                </div>
+                <div class="type-btn" data-type="out" onclick="selectType('out')">
+                    <span class="type-icon"><i class="fa-solid fa-door-closed"></i></span>
+                    <span>退室</span>
+                </div>
+            </div>
+        </section>
+
+        <!-- STEP 4: GUIDELINE (入室時のみ) -->
         <section class="card disabled-section" id="sec-guideline">
-            <div class="card-title">STEP 3: 行動指針選択</div>
+            <div class="card-title">STEP 4: 行動指針選択</div>
             <p class="guideline-hint">今日意識する指針を1つ選んでください。</p>
             <div class="guideline-list" id="guidelineList">
                 <label class="guideline-option"><input type="radio" name="guideline" value="1"><span>感謝を、当たり前に: いつも感謝を忘れない。支えられていることに気づき、全ての人・モノに感謝する。</span></label>
@@ -526,21 +541,9 @@
             </div>
         </section>
 
-        <!-- STEP 4: SCAN -->
+        <!-- STEP 5: SCAN -->
         <section class="card disabled-section" id="sec-scan">
-            <div class="card-title">STEP 4: 打刻</div>
-
-            <div class="type-switcher" id="typeSwitcher">
-                <div class="type-btn" data-type="in" onclick="selectType('in')">
-                    <span class="type-icon"><i class="fa-solid fa-door-open"></i></span>
-                    <span>入室</span>
-                </div>
-                <div class="type-btn" data-type="out" onclick="selectType('out')">
-                    <span class="type-icon"><i class="fa-solid fa-door-closed"></i></span>
-                    <span>退室</span>
-                </div>
-            </div>
-
+            <div class="card-title">STEP 5: QRコード読み取り</div>
             <div class="camera-box">
                 <video id="video" autoplay muted playsinline></video>
                 <div class="scan-line" id="scanLine"></div>
@@ -609,6 +612,7 @@
         // UI Refs
         const secStaff = document.getElementById('sec-staff');
         const secVerify = document.getElementById('sec-verify');
+        const secType = document.getElementById('sec-type');
         const secGuideline = document.getElementById('sec-guideline');
         const secScan = document.getElementById('sec-scan');
         const staffGrid = document.getElementById('staffGrid');
@@ -639,7 +643,7 @@
                         selectedGuideline = input.value;
                         secScan.classList.remove('disabled-section');
                         scrollToEl(secScan);
-                        scanStatus.textContent = "「入室」または「退室」を選択してください";
+                        if (!scanning) startCamera();
                     }
                 });
             });
@@ -724,8 +728,11 @@
             birthInput.value = '';
             verifyFeedback.textContent = '';
             selectedGuideline = null;
+            selectedType = null;
+            typeBtns.forEach(btn => btn.classList.remove('active'));
             guidelineInputs.forEach((input) => { input.checked = false; });
             document.querySelectorAll('.guideline-option').forEach((lbl) => lbl.classList.remove('selected'));
+            secType.classList.add('disabled-section');
             secGuideline.classList.add('disabled-section');
             secScan.classList.add('disabled-section');
             stopCamera();
@@ -761,8 +768,8 @@
                     verified = true;
                     verifyFeedback.textContent = 'OK: ' + res.name;
                     verifyFeedback.className = 'verify-feedback success';
-                    secGuideline.classList.remove('disabled-section');
-                    scrollToEl(secGuideline);
+                    secType.classList.remove('disabled-section');
+                    scrollToEl(secType);
                 } else {
                     verifyFeedback.textContent = '生年月日が一致しません';
                     verifyFeedback.className = 'verify-feedback error';
@@ -782,7 +789,22 @@
                 if (btn.dataset.type === type) btn.classList.add('active');
                 else btn.classList.remove('active');
             });
-            if (!scanning) startCamera();
+
+            // 入室時のみ行動指針セクションを表示。退室時はスキップして直接スキャンへ。
+            if (type === 'in') {
+                secGuideline.classList.remove('disabled-section');
+                secScan.classList.add('disabled-section');
+                stopCamera();
+                scrollToEl(secGuideline);
+            } else {
+                selectedGuideline = null;
+                guidelineInputs.forEach((input) => { input.checked = false; });
+                document.querySelectorAll('.guideline-option').forEach((lbl) => lbl.classList.remove('selected'));
+                secGuideline.classList.add('disabled-section');
+                secScan.classList.remove('disabled-section');
+                scrollToEl(secScan);
+                if (!scanning) startCamera();
+            }
         };
 
         function startCamera() {
@@ -883,6 +905,7 @@
             selectedGuideline = null;
             guidelineInputs.forEach((input) => { input.checked = false; });
             document.querySelectorAll('.guideline-option').forEach((lbl) => lbl.classList.remove('selected'));
+            secType.classList.add('disabled-section');
             secGuideline.classList.add('disabled-section');
             selectedStaffUuid = null;
             selectedStaffName = null;


### PR DESCRIPTION
## Summary
- STEP3「行動指針選択」と STEP4「打刻」の入退室タイプ選択部分の順序を入れ替え
- 入退室タイプを **本人確認直後** に選ばせ、退室時は行動指針セクションをスキップして直接QRスキャンへ
- index.html / standalone.html の両方に同じ変更を適用
- バックエンド (`Code.js`) は変更不要

## 関連 Issue
Closes #8

## 変更後のフロー

```
STEP 1: スタッフ選択
STEP 2: 本人確認
STEP 3: 入退室の選択          ← 「入室」「退室」を選ぶ
STEP 4: 行動指針選択 (入室時のみ表示)
STEP 5: QRコード読み取り
```

- **入室時**: STEP1 → 2 → 3(入室) → 4(行動指針) → 5(QR)
- **退室時**: STEP1 → 2 → 3(退室) → 5(QR) ※ STEP4 は表示すらされない

## 主な実装ポイント
- `selectType` 内で `type === 'in'` か `type === 'out'` で分岐
  - 入室 → 行動指針セクションを有効化、カメラは停止のまま
  - 退室 → 行動指針セクションを無効化＆選択クリア、即カメラ起動
- 認証成功後の遷移先を `sec-guideline` → `sec-type` に変更
- `selectStaff` / `resetApp` で `sec-type` の状態もリセット
- 行動指針選択時に「タイプ選んでね」メッセージは不要になったため、選択即カメラ起動

## Test plan
- [ ] **入室の動線**: スタッフ選択 → 生年月日入力 → 「入室」選択 → 行動指針選択 → QR読み取り → 打刻成功 / Spreadsheet G列・H列に行動指針記録
- [ ] **退室の動線**: スタッフ選択 → 生年月日入力 → 「退室」選択 → 行動指針セクションを通らず直接カメラ起動 → QR読み取り → 打刻成功 / Spreadsheet G列・H列は空
- [ ] 「入室」を選んだ後で「退室」に切り替えた場合、行動指針セクションが非表示になり選択もクリアされる
- [ ] 「退室」を選んだ後で「入室」に切り替えた場合、行動指針セクションが再度表示される
- [ ] 打刻完了後に `resetApp` が走り、すべてのSTEPが初期状態に戻る

🤖 Generated with [Claude Code](https://claude.com/claude-code)