### PR TITLE
feat: 行動指針の見出しと説明文を視覚的に分離 (closes #5)

### DIFF
--- a/index.html
+++ b/index.html
@@ -450,10 +450,31 @@
       accent-color: var(--primary);
     }
 
-    .guideline-option span {
-      font-size: 0.82rem;
-      line-height: 1.45;
+    .guideline-content {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      flex: 1;
+      min-width: 0;
+    }
+
+    .guideline-title {
+      font-size: 0.92rem;
+      font-weight: 700;
       color: var(--text-main);
+      line-height: 1.35;
+    }
+
+    .guideline-desc {
+      font-size: 0.78rem;
+      font-weight: 400;
+      color: var(--text-sub);
+      line-height: 1.5;
+      margin: 0;
+    }
+
+    .guideline-option.selected .guideline-title {
+      color: var(--primary);
     }
 
     .spinner {
@@ -517,13 +538,55 @@
       <div class="card-title">STEP 3: 行動指針選択</div>
       <p class="guideline-hint">今日意識する指針を1つ選んでください。</p>
       <div class="guideline-list" id="guidelineList">
-        <label class="guideline-option"><input type="radio" name="guideline" value="1"><span>感謝を、当たり前に: いつも感謝を忘れない。支えられていることに気づき、全ての人・モノに感謝する。</span></label>
-        <label class="guideline-option"><input type="radio" name="guideline" value="2"><span>冷笑しない: 他人の挑戦を笑わない。尊敬を忘れず、人に向き合う。挑戦する勇気を尊重する。</span></label>
-        <label class="guideline-option"><input type="radio" name="guideline" value="3"><span>相手以上に相手のことを考える: 相手の期待を超え続ける。おせっかいを恐れず、相手の未来を本気で考える。</span></label>
-        <label class="guideline-option"><input type="radio" name="guideline" value="4"><span>自ら挑み、自ずから応援される: 主体的に、挑戦する。自らの志を目的とし、応援されることを目的としてはならない。</span></label>
-        <label class="guideline-option"><input type="radio" name="guideline" value="5"><span>誠実かつ愚直に、貢献し続ける: 手を抜かず、真摯に向き合う。人の役に立つことに、本気であり続ける。</span></label>
-        <label class="guideline-option"><input type="radio" name="guideline" value="6"><span>「こんなもんか」で終わらず、一歩前へ: 現状に満足せず、常に成長する。妥協を許さず、昨日の自分を超え続ける。</span></label>
-        <label class="guideline-option"><input type="radio" name="guideline" value="7"><span>遊び心を大切に、今を生きる: 計画より実践。余白を持ち、柔軟に。今この瞬間を、全力で楽しむ。</span></label>
+        <label class="guideline-option">
+          <input type="radio" name="guideline" value="1">
+          <div class="guideline-content">
+            <strong class="guideline-title">感謝を、当たり前に</strong>
+            <p class="guideline-desc">いつも感謝を忘れない。支えられていることに気づき、全ての人・モノに感謝する。</p>
+          </div>
+        </label>
+        <label class="guideline-option">
+          <input type="radio" name="guideline" value="2">
+          <div class="guideline-content">
+            <strong class="guideline-title">冷笑しない</strong>
+            <p class="guideline-desc">他人の挑戦を笑わない。尊敬を忘れず、人に向き合う。挑戦する勇気を尊重する。</p>
+          </div>
+        </label>
+        <label class="guideline-option">
+          <input type="radio" name="guideline" value="3">
+          <div class="guideline-content">
+            <strong class="guideline-title">相手以上に相手のことを考える</strong>
+            <p class="guideline-desc">相手の期待を超え続ける。おせっかいを恐れず、相手の未来を本気で考える。</p>
+          </div>
+        </label>
+        <label class="guideline-option">
+          <input type="radio" name="guideline" value="4">
+          <div class="guideline-content">
+            <strong class="guideline-title">自ら挑み、自ずから応援される</strong>
+            <p class="guideline-desc">主体的に、挑戦する。自らの志を目的とし、応援されることを目的としてはならない。</p>
+          </div>
+        </label>
+        <label class="guideline-option">
+          <input type="radio" name="guideline" value="5">
+          <div class="guideline-content">
+            <strong class="guideline-title">誠実かつ愚直に、貢献し続ける</strong>
+            <p class="guideline-desc">手を抜かず、真摯に向き合う。人の役に立つことに、本気であり続ける。</p>
+          </div>
+        </label>
+        <label class="guideline-option">
+          <input type="radio" name="guideline" value="6">
+          <div class="guideline-content">
+            <strong class="guideline-title">「こんなもんか」で終わらず、一歩前へ</strong>
+            <p class="guideline-desc">現状に満足せず、常に成長する。妥協を許さず、昨日の自分を超え続ける。</p>
+          </div>
+        </label>
+        <label class="guideline-option">
+          <input type="radio" name="guideline" value="7">
+          <div class="guideline-content">
+            <strong class="guideline-title">遊び心を大切に、今を生きる</strong>
+            <p class="guideline-desc">計画より実践。余白を持ち、柔軟に。今この瞬間を、全力で楽しむ。</p>
+          </div>
+        </label>
       </div>
     </section>
 
@@ -841,10 +904,15 @@
       scanStatus.textContent = "送信中...";
 
       const selectedGuidelineEl = document.querySelector('input[name="guideline"]:checked');
-      const guidelineId = selectedGuidelineEl ? selectedGuidelineEl.value : '';
-      const guidelineText = selectedGuidelineEl
-        ? (selectedGuidelineEl.closest('.guideline-option')?.querySelector('span')?.textContent || '').trim()
-        : '';
+      let guidelineId = '';
+      let guidelineText = '';
+      if (selectedGuidelineEl) {
+        guidelineId = selectedGuidelineEl.value;
+        const option = selectedGuidelineEl.closest('.guideline-option');
+        const title = (option?.querySelector('.guideline-title')?.textContent || '').trim();
+        const desc = (option?.querySelector('.guideline-desc')?.textContent || '').trim();
+        guidelineText = title && desc ? `${title}: ${desc}` : (title || desc);
+      }
 
       const payload = {
         uuid: selectedStaffUuid,

--- a/standalone.html
+++ b/standalone.html
@@ -449,10 +449,31 @@
             accent-color: var(--primary);
         }
 
-        .guideline-option span {
-            font-size: 0.82rem;
-            line-height: 1.45;
+        .guideline-content {
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+            flex: 1;
+            min-width: 0;
+        }
+
+        .guideline-title {
+            font-size: 0.92rem;
+            font-weight: 700;
             color: var(--text-main);
+            line-height: 1.35;
+        }
+
+        .guideline-desc {
+            font-size: 0.78rem;
+            font-weight: 400;
+            color: var(--text-sub);
+            line-height: 1.5;
+            margin: 0;
+        }
+
+        .guideline-option.selected .guideline-title {
+            color: var(--primary);
         }
 
         .spinner {
@@ -516,13 +537,55 @@
             <div class="card-title">STEP 3: 行動指針選択</div>
             <p class="guideline-hint">今日意識する指針を1つ選んでください。</p>
             <div class="guideline-list" id="guidelineList">
-                <label class="guideline-option"><input type="radio" name="guideline" value="1"><span>感謝を、当たり前に: いつも感謝を忘れない。支えられていることに気づき、全ての人・モノに感謝する。</span></label>
-                <label class="guideline-option"><input type="radio" name="guideline" value="2"><span>冷笑しない: 他人の挑戦を笑わない。尊敬を忘れず、人に向き合う。挑戦する勇気を尊重する。</span></label>
-                <label class="guideline-option"><input type="radio" name="guideline" value="3"><span>相手以上に相手のことを考える: 相手の期待を超え続ける。おせっかいを恐れず、相手の未来を本気で考える。</span></label>
-                <label class="guideline-option"><input type="radio" name="guideline" value="4"><span>自ら挑み、自ずから応援される: 主体的に、挑戦する。自らの志を目的とし、応援されることを目的としてはならない。</span></label>
-                <label class="guideline-option"><input type="radio" name="guideline" value="5"><span>誠実かつ愚直に、貢献し続ける: 手を抜かず、真摯に向き合う。人の役に立つことに、本気であり続ける。</span></label>
-                <label class="guideline-option"><input type="radio" name="guideline" value="6"><span>「こんなもんか」で終わらず、一歩前へ: 現状に満足せず、常に成長する。妥協を許さず、昨日の自分を超え続ける。</span></label>
-                <label class="guideline-option"><input type="radio" name="guideline" value="7"><span>遊び心を大切に、今を生きる: 計画より実践。余白を持ち、柔軟に。今この瞬間を、全力で楽しむ。</span></label>
+                <label class="guideline-option">
+                    <input type="radio" name="guideline" value="1">
+                    <div class="guideline-content">
+                        <strong class="guideline-title">感謝を、当たり前に</strong>
+                        <p class="guideline-desc">いつも感謝を忘れない。支えられていることに気づき、全ての人・モノに感謝する。</p>
+                    </div>
+                </label>
+                <label class="guideline-option">
+                    <input type="radio" name="guideline" value="2">
+                    <div class="guideline-content">
+                        <strong class="guideline-title">冷笑しない</strong>
+                        <p class="guideline-desc">他人の挑戦を笑わない。尊敬を忘れず、人に向き合う。挑戦する勇気を尊重する。</p>
+                    </div>
+                </label>
+                <label class="guideline-option">
+                    <input type="radio" name="guideline" value="3">
+                    <div class="guideline-content">
+                        <strong class="guideline-title">相手以上に相手のことを考える</strong>
+                        <p class="guideline-desc">相手の期待を超え続ける。おせっかいを恐れず、相手の未来を本気で考える。</p>
+                    </div>
+                </label>
+                <label class="guideline-option">
+                    <input type="radio" name="guideline" value="4">
+                    <div class="guideline-content">
+                        <strong class="guideline-title">自ら挑み、自ずから応援される</strong>
+                        <p class="guideline-desc">主体的に、挑戦する。自らの志を目的とし、応援されることを目的としてはならない。</p>
+                    </div>
+                </label>
+                <label class="guideline-option">
+                    <input type="radio" name="guideline" value="5">
+                    <div class="guideline-content">
+                        <strong class="guideline-title">誠実かつ愚直に、貢献し続ける</strong>
+                        <p class="guideline-desc">手を抜かず、真摯に向き合う。人の役に立つことに、本気であり続ける。</p>
+                    </div>
+                </label>
+                <label class="guideline-option">
+                    <input type="radio" name="guideline" value="6">
+                    <div class="guideline-content">
+                        <strong class="guideline-title">「こんなもんか」で終わらず、一歩前へ</strong>
+                        <p class="guideline-desc">現状に満足せず、常に成長する。妥協を許さず、昨日の自分を超え続ける。</p>
+                    </div>
+                </label>
+                <label class="guideline-option">
+                    <input type="radio" name="guideline" value="7">
+                    <div class="guideline-content">
+                        <strong class="guideline-title">遊び心を大切に、今を生きる</strong>
+                        <p class="guideline-desc">計画より実践。余白を持ち、柔軟に。今この瞬間を、全力で楽しむ。</p>
+                    </div>
+                </label>
             </div>
         </section>
 
@@ -834,10 +897,15 @@
             scanStatus.textContent = "送信中...";
 
             const selectedGuidelineEl = document.querySelector('input[name="guideline"]:checked');
-            const guidelineId = selectedGuidelineEl ? selectedGuidelineEl.value : '';
-            const guidelineText = selectedGuidelineEl
-                ? (selectedGuidelineEl.closest('.guideline-option')?.querySelector('span')?.textContent || '').trim()
-                : '';
+            let guidelineId = '';
+            let guidelineText = '';
+            if (selectedGuidelineEl) {
+                guidelineId = selectedGuidelineEl.value;
+                const option = selectedGuidelineEl.closest('.guideline-option');
+                const title = (option?.querySelector('.guideline-title')?.textContent || '').trim();
+                const desc = (option?.querySelector('.guideline-desc')?.textContent || '').trim();
+                guidelineText = title && desc ? `${title}: ${desc}` : (title || desc);
+            }
 
             const payload = {
                 uuid: selectedStaffUuid,


### PR DESCRIPTION
## Summary
- 各行動指針の項目を **「見出し」と「説明文」** の2階層に分割
- CSSで見出しは太字＋メインカラー、説明文は小さめ＋サブカラーに区別
- 選択中の項目は見出しもプライマリカラーに変化
- index.html / standalone.html の両方に適用

## 関連 Issue
Closes #5

## 変更前後

### Before
```html
<label class="guideline-option">
  <input type="radio" name="guideline" value="1">
  <span>感謝を、当たり前に: いつも感謝を忘れない。支えられていることに気づき、全ての人・モノに感謝する。</span>
</label>
```
全文が同じスタイルで表示されるため、見出しと説明文の区別がつきにくかった。

### After
```html
<label class="guideline-option">
  <input type="radio" name="guideline" value="1">
  <div class="guideline-content">
    <strong class="guideline-title">感謝を、当たり前に</strong>
    <p class="guideline-desc">いつも感謝を忘れない。支えられていることに気づき、全ての人・モノに感謝する。</p>
  </div>
</label>
```

## CSS設計
| クラス | スタイル | 役割 |
|---|---|---|
| `.guideline-title` | 0.92rem / weight 700 / `--text-main` | 見出し |
| `.guideline-desc` | 0.78rem / weight 400 / `--text-sub` | 説明文 |
| `.guideline-option.selected .guideline-title` | `--primary` | 選択時の強調 |

## データ互換性
- `handleQrCode` を新HTML構造から「見出し: 説明文」の形式に組み立てるよう更新
- GAS へ送る `guidelineText` の形式は **従来と完全に同一**
- 打刻記録シートに既に保存されているデータと整合性あり

## Test plan
- [ ] 7項目すべてが「見出し（太字）」「説明文（やや小さく薄め）」で表示される
- [ ] 項目をタップ／クリックすると見出しがプライマリカラー（紫）に変化、ボーダーも変わる
- [ ] 打刻完了後、Spreadsheet の `guidelineText` 列に従来通り「○○○: △△△」の形式で記録される
- [ ] モバイル幅（420px 以下）でも見出し・説明文が読みやすく折り返される

🤖 Generated with [Claude Code](https://claude.com/claude-code)