### PR TITLE
fix: 入室フローで行動指針選択後にカメラが起動しないバグを修正 (#13)

### DIFF
--- a/horizontal/index.html
+++ b/horizontal/index.html
@@ -1027,7 +1027,7 @@
       selectedGuideline = value;
       secScan.classList.remove('disabled-section');
       scrollToEl(secScan);
-      scanStatus.textContent = "「入室」または「退室」を選択してください";
+      if (!scanning) startCamera();
     }
 
     // --- Init ---

--- a/index.html
+++ b/index.html
@@ -1032,7 +1032,7 @@
       selectedGuideline = value;
       secScan.classList.remove('disabled-section');
       scrollToEl(secScan);
-      scanStatus.textContent = "「入室」または「退室」を選択してください";
+      if (!scanning) startCamera();
     }
 
     // --- Init ---

--- a/normal/index.html
+++ b/normal/index.html
@@ -883,7 +883,7 @@
       selectedGuideline = value;
       secScan.classList.remove('disabled-section');
       scrollToEl(secScan);
-      scanStatus.textContent = "「入室」または「退室」を選択してください";
+      if (!scanning) startCamera();
     }
 
     // --- Init ---


### PR DESCRIPTION
## 概要

入室フローでSTEP3（行動指針選択）完了後、STEP4（打刻）のカメラが起動しないバグを修正。

## 原因

`onGuidelineSelected()` 内に旧フロー由来のメッセージ設定が残っており、`startCamera()` が呼ばれていなかった。

```
// 旧フロー（行動指針 → タイプ選択）の名残
scanStatus.textContent = "「入室」または「退室」を選択してください"; // ← 削除
```

現行フロー（タイプ選択 → 行動指針選択）では、行動指針選択時点でタイプ（入室）は確定済み。なので直接 `startCamera()` を呼ぶのが正しい。

退室フローは `selectType('out')` 内で直接 `startCamera()` が呼ばれているため正常動作していた。

## 変更ファイル

- `index.html`
- `horizontal/index.html`
- `normal/index.html`

## 変更内容

```diff
- scanStatus.textContent = "「入室」または「退室」を選択してください";
+ if (!scanning) startCamera();
```

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)