### PR TITLE
feat: スタッフDBをSpreadsheet→Firestore読み込みへ移行 + 全支部対応

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -1,5 +1,10 @@
-const STAFF_SHEET_NAME = 'スタッフDB';
 const TIMESTAMP_SHEET_NAME = '打刻記録';
+
+// Firestore（AccountForm のスタッフDB）
+const FIRESTORE_COLLECTION = 'staff';
+const INTERN_ATTRIBUTE = 'インターン学生';
+// 拠点ID → 支部名（フロントの PLACE_NAMES と対応）
+const PLACE_TO_BRANCH = { tokyo: '東京', niigata: '新潟', nagoya: '名古屋', fukuoka: '福岡' };
 
 /**
  * メイン画面表示 / API エンドポイント
@@ -13,7 +18,7 @@ function doGet(e) {
       let result;
       switch (action) {
         case 'getStaffList':
-          result = getStaffList();
+          result = getStaffList(e.parameter.place);
           break;
         case 'verifyStaff':
           result = verifyStaff(e.parameter.uuid, e.parameter.birthdate);
@@ -24,7 +29,7 @@ function doGet(e) {
           result = recordTimestamp(payload);
           break;
         case 'clearStaffCache':
-          result = clearStaffCache();
+          result = clearStaffCache(e.parameter.place);
           break;
         default:
           throw new Error('Unknown action: ' + action);
@@ -66,50 +71,270 @@ function include(filename) {
   return HtmlService.createHtmlOutputFromFile(filename).getContent();
 }
 
+/* ============================================================
+ * Firestore アクセス（サービスアカウント + REST）
+ * 認証情報はスクリプトプロパティで管理する（コード直書き禁止）:
+ *   FIRESTORE_PROJECT_ID  例: amazing-centaur-468005-b0
+ *   FIRESTORE_DATABASE_ID 例: accountform
+ *   SA_CLIENT_EMAIL       サービスアカウントの client_email
+ *   SA_PRIVATE_KEY        サービスアカウントの private_key（\n を含む全文）
+ * ============================================================ */
+
+/**
+ * Firestore 接続設定をスクリプトプロパティから取得
+ */
+function getFirestoreConfig_() {
+  const props = PropertiesService.getScriptProperties();
+  const projectId = props.getProperty('FIRESTORE_PROJECT_ID');
+  const databaseId = props.getProperty('FIRESTORE_DATABASE_ID') || '(default)';
+  if (!projectId) {
+    throw new Error('FIRESTORE_PROJECT_ID が未設定です（スクリプトプロパティ）');
+  }
+  return { projectId: projectId, databaseId: databaseId };
+}
+
+/**
+ * Base64 URL-safe エンコード（パディング除去）
+ */
+function base64UrlEncode_(input) {
+  return Utilities.base64EncodeWebSafe(input).replace(/=+$/, '');
+}
+
+/**
+ * サービスアカウントで Firestore 用の OAuth2 アクセストークンを取得する。
+ * JWT(RS256) を自前で署名し、jwt-bearer グラントで交換する。
+ * 取得したトークンは約55分キャッシュする。
+ */
+function getFirestoreToken_() {
+  const cache = CacheService.getScriptCache();
+  const cached = cache.get('fs_access_token');
+  if (cached) return cached;
+
+  const props = PropertiesService.getScriptProperties();
+  let clientEmail = props.getProperty('SA_CLIENT_EMAIL');
+  let privateKey = props.getProperty('SA_PRIVATE_KEY');
+  if (!privateKey) {
+    throw new Error('サービスアカウント認証情報(SA_PRIVATE_KEY)が未設定です');
+  }
+
+  privateKey = privateKey.trim();
+
+  // サービスアカウントJSON全体が貼られていた場合は private_key を取り出す。
+  // その JSON の client_email は秘密鍵と必ず対になるため、iss 不一致による
+  // "Invalid JWT Signature" を避けるべく、別途設定の SA_CLIENT_EMAIL より優先する。
+  if (privateKey.charAt(0) === '{') {
+    try {
+      const obj = JSON.parse(privateKey);
+      if (obj && obj.private_key) {
+        privateKey = obj.private_key;
+        if (obj.client_email) clientEmail = obj.client_email;
+      }
+    } catch (e) {
+      // JSON でなければそのまま続行
+    }
+  }
+
+  if (!clientEmail) {
+    throw new Error('サービスアカウント認証情報(SA_CLIENT_EMAIL)が未設定です');
+  }
+
+  // 貼り付けゆれを正規化する:
+  //  - JSON からコピーした際に付く両端の二重引用符を除去
+  //  - エスケープされた改行(\r\n / \n)および CRLF を実改行へ変換
+  if (privateKey.charAt(0) === '"' && privateKey.charAt(privateKey.length - 1) === '"') {
+    privateKey = privateKey.slice(1, -1);
+  }
+  privateKey = privateKey
+    .replace(/\\r\\n/g, '\n')
+    .replace(/\\n/g, '\n')
+    .replace(/\r\n/g, '\n');
+
+  const now = Math.floor(Date.now() / 1000);
+  const header = { alg: 'RS256', typ: 'JWT' };
+  const claim = {
+    iss: clientEmail,
+    scope: 'https://www.googleapis.com/auth/datastore',
+    aud: 'https://oauth2.googleapis.com/token',
+    iat: now,
+    exp: now + 3600
+  };
+  const toSign = base64UrlEncode_(JSON.stringify(header)) + '.' + base64UrlEncode_(JSON.stringify(claim));
+  const signature = Utilities.computeRsaSha256Signature(toSign, privateKey);
+  const jwt = toSign + '.' + base64UrlEncode_(signature);
+
+  const res = UrlFetchApp.fetch('https://oauth2.googleapis.com/token', {
+    method: 'post',
+    contentType: 'application/x-www-form-urlencoded',
+    payload: {
+      grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+      assertion: jwt
+    },
+    muteHttpExceptions: true
+  });
+  const body = JSON.parse(res.getContentText());
+  if (res.getResponseCode() !== 200 || !body.access_token) {
+    throw new Error('Firestoreアクセストークン取得に失敗: ' + res.getContentText());
+  }
+  cache.put('fs_access_token', body.access_token, 3300);
+  return body.access_token;
+}
+
+/**
+ * Firestore REST の型付き値（{stringValue:...} など）を素の値へ変換する
+ */
+function fsValue_(field) {
+  if (field == null) return null;
+  if (field.stringValue !== undefined) return field.stringValue;
+  if (field.booleanValue !== undefined) return field.booleanValue;
+  if (field.integerValue !== undefined) return Number(field.integerValue);
+  if (field.doubleValue !== undefined) return field.doubleValue;
+  if (field.timestampValue !== undefined) return field.timestampValue;
+  if (field.nullValue !== undefined) return null;
+  if (field.mapValue !== undefined) {
+    const out = {};
+    const f = (field.mapValue && field.mapValue.fields) || {};
+    Object.keys(f).forEach(function (k) { out[k] = fsValue_(f[k]); });
+    return out;
+  }
+  if (field.arrayValue !== undefined) {
+    const vals = (field.arrayValue && field.arrayValue.values) || [];
+    return vals.map(fsValue_);
+  }
+  return null;
+}
+
+/**
+ * 拠点ID(place) を支部名へ変換する。未知/空なら null（=支部で絞らない）
+ */
+function placeToBranch_(place) {
+  if (!place) return null;
+  return PLACE_TO_BRANCH[place] || null;
+}
+
+/**
+ * 生年月日を YYYY-MM-DD 文字列へ正規化する。
+ * Firestore では文字列(YYYY-MM-DD)前提だが、timestamp 等で入っていても対応する。
+ */
+function normalizeBirthdate_(val) {
+  if (!val) return '';
+  if (typeof val === 'string') {
+    const m = val.match(/^\d{4}-\d{2}-\d{2}/);
+    if (m) return m[0];
+    const d = new Date(val);
+    if (!isNaN(d.getTime())) {
+      return Utilities.formatDate(d, Session.getScriptTimeZone(), 'yyyy-MM-dd');
+    }
+    return String(val);
+  }
+  try {
+    return Utilities.formatDate(new Date(val), Session.getScriptTimeZone(), 'yyyy-MM-dd');
+  } catch (e) {
+    return String(val);
+  }
+}
+
+/**
+ * Firestore staff コレクションを属性=インターン学生（＋支部）で絞り込んで取得する。
+ * 戻り値は各ドキュメントの fields オブジェクトの配列。
+ * @param {string|null} branch 支部名。null なら支部で絞らない。
+ */
+function queryStaffDocs_(branch) {
+  const conf = getFirestoreConfig_();
+  const token = getFirestoreToken_();
+  const url = 'https://firestore.googleapis.com/v1/projects/' + conf.projectId +
+    '/databases/' + conf.databaseId + '/documents:runQuery';
+
+  const attributeFilter = {
+    fieldFilter: {
+      field: { fieldPath: 'attribute' },
+      op: 'EQUAL',
+      value: { stringValue: INTERN_ATTRIBUTE }
+    }
+  };
+
+  let where;
+  if (branch) {
+    where = {
+      compositeFilter: {
+        op: 'AND',
+        filters: [
+          attributeFilter,
+          {
+            fieldFilter: {
+              field: { fieldPath: 'branch' },
+              op: 'EQUAL',
+              value: { stringValue: branch }
+            }
+          }
+        ]
+      }
+    };
+  } else {
+    where = attributeFilter;
+  }
+
+  const body = {
+    structuredQuery: {
+      from: [{ collectionId: FIRESTORE_COLLECTION }],
+      where: where
+    }
+  };
+
+  const res = UrlFetchApp.fetch(url, {
+    method: 'post',
+    contentType: 'application/json',
+    headers: { Authorization: 'Bearer ' + token },
+    payload: JSON.stringify(body),
+    muteHttpExceptions: true
+  });
+  if (res.getResponseCode() !== 200) {
+    throw new Error('Firestore runQuery 失敗 (' + res.getResponseCode() + '): ' + res.getContentText());
+  }
+
+  const rows = JSON.parse(res.getContentText());
+  const docs = [];
+  rows.forEach(function (row) {
+    if (row.document && row.document.fields) {
+      docs.push(row.document.fields);
+    }
+  });
+  return docs;
+}
+
 /**
  * スタッフ一覧を取得（プルダウン用）
- * キャッシュを利用して高速化する
+ * Firestore から 属性=インターン学生・現役（退職/卒業フラグなし）を取得し、
+ * place 指定時はその支部のみに絞る。キャッシュで高速化する。
  * return: [{ uuid, name, birthdate, img }, ...]
  */
-function getStaffList() {
-  const cacheKey = 'staff_list_cache';
+function getStaffList(place) {
+  const branch = placeToBranch_(place);
+  const cacheKey = 'staff_list_cache_' + (branch || 'all');
   const cache = CacheService.getScriptCache();
   const cachedData = cache.get(cacheKey);
 
   if (cachedData) {
-    console.log('Using cached staff list');
+    console.log('Using cached staff list: ' + cacheKey);
     return JSON.parse(cachedData);
   }
 
-  console.log('Cache miss. Fetching from Spreadsheet');
-  const ss = SpreadsheetApp.getActiveSpreadsheet();
-  const sheet = ss.getSheetByName(STAFF_SHEET_NAME);
-  if (!sheet) {
-    throw new Error('staffs シートが見つかりません');
-  }
-
-  const values = sheet.getDataRange().getValues();
-  const header = values[0];
-  const uuidIndex = header.indexOf('uuid');
-  const nameIndex = header.indexOf('name');
-  const birthIndex = header.indexOf('birthdate');
-  const imgIndex = header.indexOf('img');
-
-  if (uuidIndex === -1 || nameIndex === -1 || birthIndex === -1) {
-    throw new Error('staffs シートに uuid / name / birthdate 列がありません');
-  }
+  console.log('Cache miss. Fetching from Firestore (branch=' + (branch || 'all') + ')');
+  const fieldsList = queryStaffDocs_(branch);
 
   const result = [];
-  for (let i = 1; i < values.length; i++) {
-    const row = values[i];
-    if (!row[uuidIndex] || !row[nameIndex]) continue;
+  fieldsList.forEach(function (f) {
+    // 退職/卒業フラグが立っている人は除外（欠落/false/0 は現役扱い）
+    if (fsValue_(f.graduatedFlag) === true) return;
+    const uuid = fsValue_(f.staffId);
+    const name = fsValue_(f.fullName);
+    if (!uuid || !name) return;
     result.push({
-      uuid: String(row[uuidIndex]),
-      name: String(row[nameIndex]),
-      birthdate: row[birthIndex] ? Utilities.formatDate(new Date(row[birthIndex]), Session.getScriptTimeZone(), 'yyyy-MM-dd') : '',
-      img: row[imgIndex] ? String(row[imgIndex]) : ''
+      uuid: String(uuid),
+      name: String(name),
+      birthdate: normalizeBirthdate_(fsValue_(f.birthDate)),
+      img: f.photoUrl ? String(fsValue_(f.photoUrl) || '') : ''
     });
-  }
+  });
 
   // キャッシュに保存（有効期限は6時間 = 21600秒）
   try {
@@ -122,11 +347,13 @@ function getStaffList() {
 }
 
 /**
- * スタッフ一覧のキャッシュを明示的にクリアする
+ * スタッフ一覧のキャッシュを明示的にクリアする（拠点別）
  */
-function clearStaffCache() {
+function clearStaffCache(place) {
   const cache = CacheService.getScriptCache();
-  cache.remove('staff_list_cache');
+  const branch = placeToBranch_(place);
+  const cacheKey = 'staff_list_cache_' + (branch || 'all');
+  cache.remove(cacheKey);
   return { ok: true, message: 'キャッシュをクリアしました' };
 }
 
@@ -137,47 +364,36 @@ function clearStaffCache() {
  * @returns {{ok: boolean, name?: string, message?: string}}
  */
 function verifyStaff(uuid, birthdateStr) {
-  const ss = SpreadsheetApp.getActiveSpreadsheet();
-  const sheet = ss.getSheetByName(STAFF_SHEET_NAME);
-  if (!sheet) {
-    return { ok: false, message: 'staffs シートが見つかりません' };
+  if (!uuid) return { ok: false, message: 'スタッフが指定されていません' };
+
+  const conf = getFirestoreConfig_();
+  const token = getFirestoreToken_();
+  const url = 'https://firestore.googleapis.com/v1/projects/' + conf.projectId +
+    '/databases/' + conf.databaseId + '/documents/' + FIRESTORE_COLLECTION + '/' + encodeURIComponent(uuid);
+
+  const res = UrlFetchApp.fetch(url, {
+    method: 'get',
+    headers: { Authorization: 'Bearer ' + token },
+    muteHttpExceptions: true
+  });
+  const code = res.getResponseCode();
+  if (code === 404) {
+    return { ok: false, message: '該当のスタッフが見つかりません' };
+  }
+  if (code !== 200) {
+    return { ok: false, message: 'スタッフ情報の取得に失敗しました (' + code + ')' };
   }
 
-  const values = sheet.getDataRange().getValues();
-  const header = values[0];
-  const uuidIndex = header.indexOf('uuid');
-  const nameIndex = header.indexOf('name');
-  const birthIndex = header.indexOf('birthdate');
+  const doc = JSON.parse(res.getContentText());
+  const fields = doc.fields || {};
+  const name = String(fsValue_(fields.fullName) || '');
+  const cellStr = normalizeBirthdate_(fsValue_(fields.birthDate));
+  const normalizedInput = String(birthdateStr || '').trim();
 
-  if (uuidIndex === -1 || nameIndex === -1 || birthIndex === -1) {
-    return { ok: false, message: 'staffs シートに uuid / name / birthdate 列がありません' };
+  if (cellStr && cellStr === normalizedInput) {
+    return { ok: true, name: name };
   }
-
-  // 入力された birthdateStr を Dateとして扱う
-  const normalizedInput = birthdateStr.trim();
-
-  for (let i = 1; i < values.length; i++) {
-    const row = values[i];
-    if (String(row[uuidIndex]) !== String(uuid)) continue;
-
-    const name = String(row[nameIndex]);
-    const cell = row[birthIndex];
-    let cellStr = '';
-
-    if (cell instanceof Date) {
-      cellStr = Utilities.formatDate(cell, Session.getScriptTimeZone(), 'yyyy-MM-dd');
-    } else {
-      cellStr = String(cell);
-    }
-
-    if (cellStr === normalizedInput) {
-      return { ok: true, name };
-    } else {
-      return { ok: false, message: '生年月日が一致しません' };
-    }
-  }
-
-  return { ok: false, message: '該当のスタッフが見つかりません' };
+  return { ok: false, message: '生年月日が一致しません' };
 }
 
 /**
@@ -233,4 +449,3 @@ function recordTimestamp(payload) {
     message: message
   };
 }
-

--- a/appsscript.json
+++ b/appsscript.json
@@ -3,6 +3,11 @@
   "dependencies": {},
   "exceptionLogging": "STACKDRIVER",
   "runtimeVersion": "V8",
+  "oauthScopes": [
+    "https://www.googleapis.com/auth/spreadsheets.currentonly",
+    "https://www.googleapis.com/auth/script.external_request",
+    "https://www.googleapis.com/auth/userinfo.email"
+  ],
   "webapp": {
     "executeAs": "USER_DEPLOYING",
     "access": "ANYONE_ANONYMOUS"

--- a/fukuoka/index.html
+++ b/fukuoka/index.html
@@ -1079,7 +1079,7 @@
     // --- 1. Staff List ---
     async function initStaffList() {
       try {
-        const list = await callGas('getStaffList');
+        const list = await callGas('getStaffList', { place: placeId });
         renderStaffList(list);
       } catch (err) {
         staffGrid.innerHTML = '<div style="color:red; grid-column:1/-1;">エラー: ' + err.message + '</div>';
@@ -1132,10 +1132,10 @@
       staffGrid.innerHTML = '<div style="grid-column: 1 / -1; text-align: center; padding: 20px; color: var(--text-sub);"><div class="spinner"></div> キャッシュを更新中...</div>';
 
       try {
-        const res = await callGas('clearStaffCache');
+        const res = await callGas('clearStaffCache', { place: placeId });
         if (res.ok) {
           showToast('キャッシュを更新しました', 'success');
-          const list = await callGas('getStaffList');
+          const list = await callGas('getStaffList', { place: placeId });
           btn.classList.remove('spinning');
           renderStaffList(list);
         }

--- a/horizontal/index.html
+++ b/horizontal/index.html
@@ -1074,7 +1074,7 @@
     // --- 1. Staff List ---
     async function initStaffList() {
       try {
-        const list = await callGas('getStaffList');
+        const list = await callGas('getStaffList', { place: placeId });
         renderStaffList(list);
       } catch (err) {
         staffGrid.innerHTML = '<div style="color:red; grid-column:1/-1;">エラー: ' + err.message + '</div>';
@@ -1127,10 +1127,10 @@
       staffGrid.innerHTML = '<div style="grid-column: 1 / -1; text-align: center; padding: 20px; color: var(--text-sub);"><div class="spinner"></div> キャッシュを更新中...</div>';
 
       try {
-        const res = await callGas('clearStaffCache');
+        const res = await callGas('clearStaffCache', { place: placeId });
         if (res.ok) {
           showToast('キャッシュを更新しました', 'success');
-          const list = await callGas('getStaffList');
+          const list = await callGas('getStaffList', { place: placeId });
           btn.classList.remove('spinning');
           renderStaffList(list);
         }

--- a/index.html
+++ b/index.html
@@ -1079,7 +1079,7 @@
     // --- 1. Staff List ---
     async function initStaffList() {
       try {
-        const list = await callGas('getStaffList');
+        const list = await callGas('getStaffList', { place: placeId });
         renderStaffList(list);
       } catch (err) {
         staffGrid.innerHTML = '<div style="color:red; grid-column:1/-1;">エラー: ' + err.message + '</div>';
@@ -1132,10 +1132,10 @@
       staffGrid.innerHTML = '<div style="grid-column: 1 / -1; text-align: center; padding: 20px; color: var(--text-sub);"><div class="spinner"></div> キャッシュを更新中...</div>';
 
       try {
-        const res = await callGas('clearStaffCache');
+        const res = await callGas('clearStaffCache', { place: placeId });
         if (res.ok) {
           showToast('キャッシュを更新しました', 'success');
-          const list = await callGas('getStaffList');
+          const list = await callGas('getStaffList', { place: placeId });
           btn.classList.remove('spinning');
           renderStaffList(list);
         }

--- a/nagoya/index.html
+++ b/nagoya/index.html
@@ -1079,7 +1079,7 @@
     // --- 1. Staff List ---
     async function initStaffList() {
       try {
-        const list = await callGas('getStaffList');
+        const list = await callGas('getStaffList', { place: placeId });
         renderStaffList(list);
       } catch (err) {
         staffGrid.innerHTML = '<div style="color:red; grid-column:1/-1;">エラー: ' + err.message + '</div>';
@@ -1132,10 +1132,10 @@
       staffGrid.innerHTML = '<div style="grid-column: 1 / -1; text-align: center; padding: 20px; color: var(--text-sub);"><div class="spinner"></div> キャッシュを更新中...</div>';
 
       try {
-        const res = await callGas('clearStaffCache');
+        const res = await callGas('clearStaffCache', { place: placeId });
         if (res.ok) {
           showToast('キャッシュを更新しました', 'success');
-          const list = await callGas('getStaffList');
+          const list = await callGas('getStaffList', { place: placeId });
           btn.classList.remove('spinning');
           renderStaffList(list);
         }

--- a/niigata/index.html
+++ b/niigata/index.html
@@ -1079,7 +1079,7 @@
     // --- 1. Staff List ---
     async function initStaffList() {
       try {
-        const list = await callGas('getStaffList');
+        const list = await callGas('getStaffList', { place: placeId });
         renderStaffList(list);
       } catch (err) {
         staffGrid.innerHTML = '<div style="color:red; grid-column:1/-1;">エラー: ' + err.message + '</div>';
@@ -1132,10 +1132,10 @@
       staffGrid.innerHTML = '<div style="grid-column: 1 / -1; text-align: center; padding: 20px; color: var(--text-sub);"><div class="spinner"></div> キャッシュを更新中...</div>';
 
       try {
-        const res = await callGas('clearStaffCache');
+        const res = await callGas('clearStaffCache', { place: placeId });
         if (res.ok) {
           showToast('キャッシュを更新しました', 'success');
-          const list = await callGas('getStaffList');
+          const list = await callGas('getStaffList', { place: placeId });
           btn.classList.remove('spinning');
           renderStaffList(list);
         }

--- a/normal/index.html
+++ b/normal/index.html
@@ -930,7 +930,7 @@
     // --- 1. Staff List ---
     async function initStaffList() {
       try {
-        const list = await callGas('getStaffList');
+        const list = await callGas('getStaffList', { place: placeId });
         renderStaffList(list);
       } catch (err) {
         staffGrid.innerHTML = '<div style="color:red; grid-column:1/-1;">エラー: ' + err.message + '</div>';
@@ -983,10 +983,10 @@
       staffGrid.innerHTML = '<div style="grid-column: 1 / -1; text-align: center; padding: 20px; color: var(--text-sub);"><div class="spinner"></div> キャッシュを更新中...</div>';
 
       try {
-        const res = await callGas('clearStaffCache');
+        const res = await callGas('clearStaffCache', { place: placeId });
         if (res.ok) {
           showToast('キャッシュを更新しました', 'success');
-          const list = await callGas('getStaffList');
+          const list = await callGas('getStaffList', { place: placeId });
           btn.classList.remove('spinning');
           renderStaffList(list);
         }

--- a/standalone.html
+++ b/standalone.html
@@ -774,7 +774,7 @@
         // --- 1. Staff List ---
         async function initStaffList() {
             try {
-                const list = await callGas('getStaffList');
+                const list = await callGas('getStaffList', { place: placeId });
                 renderStaffList(list);
             } catch (err) {
                 staffGrid.innerHTML = '<div style="color:red; grid-column:1/-1;">エラー: ' + err.message + '</div>';
@@ -827,10 +827,10 @@
             staffGrid.innerHTML = '<div style="grid-column: 1 / -1; text-align: center; padding: 20px; color: var(--text-sub);"><div class="spinner"></div> キャッシュを更新中...</div>';
 
             try {
-                const res = await callGas('clearStaffCache');
+                const res = await callGas('clearStaffCache', { place: placeId });
                 if (res.ok) {
                     showToast('キャッシュを更新しました', 'success');
-                    const list = await callGas('getStaffList');
+                    const list = await callGas('getStaffList', { place: placeId });
                     btn.classList.remove('spinning');
                     renderStaffList(list);
                 }

--- a/tokyo/index.html
+++ b/tokyo/index.html
@@ -1079,7 +1079,7 @@
     // --- 1. Staff List ---
     async function initStaffList() {
       try {
-        const list = await callGas('getStaffList');
+        const list = await callGas('getStaffList', { place: placeId });
         renderStaffList(list);
       } catch (err) {
         staffGrid.innerHTML = '<div style="color:red; grid-column:1/-1;">エラー: ' + err.message + '</div>';
@@ -1132,10 +1132,10 @@
       staffGrid.innerHTML = '<div style="grid-column: 1 / -1; text-align: center; padding: 20px; color: var(--text-sub);"><div class="spinner"></div> キャッシュを更新中...</div>';
 
       try {
-        const res = await callGas('clearStaffCache');
+        const res = await callGas('clearStaffCache', { place: placeId });
         if (res.ok) {
           showToast('キャッシュを更新しました', 'success');
-          const list = await callGas('getStaffList');
+          const list = await callGas('getStaffList', { place: placeId });
           btn.classList.remove('spinning');
           renderStaffList(list);
         }


### PR DESCRIPTION
## Summary
- スタッフリストの読み込みを Google Spreadsheet (`スタッフDB`シート) から AccountForm の Firestore (`staff` コレクション) 直読みへ移行
- 対象を「属性=インターン学生・現役(退職/卒業フラグなし)」とし、拠点(`placeId`)→支部でキオスクごとに絞り込み（全支部対応: tokyo→東京 / nagoya→名古屋 / niigata→新潟 / fukuoka→福岡）
- サービスアカウントで JWT(RS256) を自前署名 → OAuth2 トークン交換 → Firestore REST API を呼び出し。認証情報はスクリプトプロパティ管理（コード直書きなし）
- 各フロントHTMLで `getStaffList`/`clearStaffCache` に `place` を付与
- `appsscript.json` に `script.external_request` 等のスコープを明示
- `recordTimestamp`(打刻記録シート)は従来通り維持、未使用の `STAFF_SHEET_NAME` を削除

## 必要なセットアップ（本番では設定済み）
- スクリプトプロパティ: `FIRESTORE_PROJECT_ID` / `FIRESTORE_DATABASE_ID`(=accountform) / `SA_CLIENT_EMAIL` / `SA_PRIVATE_KEY`
  - `SA_PRIVATE_KEY` はサービスアカウントJSON全体の貼り付けにも対応（`private_key`/`client_email`を自動抽出）
- GCP `amazing-centaur-468005-b0` のサービスアカウントに `roles/datastore.viewer`

## デプロイ状況
- 本番 GAS Web アプリは既に v35 へ更新・動作確認済み（getStaffList 支部別取得 / verifyStaff 正誤判定）
- GitHub Pages は main/root 配信のため、**本PRを main にマージするとフロントの `place` 対応が自動反映**される（マージ前はライブのフロントが `place` なしで呼ぶため、バックエンドのフォールバックで全支部表示になる）

## Test plan
- [x] `getStaffList?place=tokyo/nagoya/fukuoka` が各支部のインターン学生(現役)のみ返す
- [x] `verifyStaff` 正=OK＋氏名 / 誤=不一致 / 存在しない=該当なし
- [ ] 実機キオスク(`/tokyo/` 等)で支部別表示・アバター画像・生年月日認証→打刻の一連
- [ ] キャッシュ更新ボタンで支部別キャッシュがクリア＆再取得

🤖 Generated with [Claude Code](https://claude.com/claude-code)