### PR TITLE
fix: 生年月日認証の1日ズレを修正 (FirestoreタイムスタンプをJST日付化)

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -218,12 +218,18 @@ function placeToBranch_(place) {
 function normalizeBirthdate_(val) {
   if (!val) return '';
   if (typeof val === 'string') {
-    const m = val.match(/^\d{4}-\d{2}-\d{2}/);
-    if (m) return m[0];
-    const d = new Date(val);
-    if (!isNaN(d.getTime())) {
-      return Utilities.formatDate(d, Session.getScriptTimeZone(), 'yyyy-MM-dd');
+    // 時刻付きISO/タイムスタンプ(Firestore timestampValue 等)は、UTCの日付を
+    // そのまま拾うと1日ズレるため、スクリプトTZ(Asia/Tokyo)で日付化する。
+    if (val.indexOf('T') >= 0) {
+      const d = new Date(val);
+      if (!isNaN(d.getTime())) {
+        return Utilities.formatDate(d, Session.getScriptTimeZone(), 'yyyy-MM-dd');
+      }
     }
+    // 区切りを '-' に寄せ、先頭の YYYY-MM-DD を取り出す
+    const s = val.replace(/\//g, '-');
+    const m = s.match(/^\d{4}-\d{2}-\d{2}/);
+    if (m) return m[0];
     return String(val);
   }
   try {


### PR DESCRIPTION
## 背景 / 不具合
Firestore移行(#17)後、生年月日認証が常に「生年月日が一致しません」になっていた。

## 原因
AccountForm は `birthDate` を **Firestore Timestamp(UTC)** で保存している（例: `2006-03-28T15:00:00Z` = JST `2006-03-29 00:00`）。移行時の実装はタイムスタンプ文字列から **UTCの日付部分をそのまま抽出**していたため、JSTの実誕生日より1日早い日付（`2006-03-28`）と比較してしまい、スタッフが入力する実誕生日（`2006-03-29`）と一致しなかった。旧スプレッドシート版は Date を `Asia/Tokyo` で整形していたため正しく動作していた。

## 修正
`normalizeBirthdate_` を変更し、時刻付き値(ISO/タイムスタンプ)は `Session.getScriptTimeZone()`(=Asia/Tokyo) で `yyyy-MM-dd` 化する。純粋な `YYYY-MM-DD` 文字列はそのまま、`/` 区切りも吸収。

## デプロイ / 検証
- 本番 GAS は既に **v37** へ更新済み・全支部キャッシュをクリア済み
- 本番URLで検証: 実誕生日(JST)=`ok:true` / 旧UTCズレ日付=不一致 を確認
- このPRは Code.js のみの変更（GitHub Pages の配信物には影響なし。記録目的でmainへ取り込み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)